### PR TITLE
Add common MariaDB 10.0 client and server packages

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -3642,6 +3642,10 @@ libmagickwand4
 libmagickwand4:i386
 libmail-sendmail-perl
 libmail-sendmail-perl:i386
+libmariadbclient-dev
+libmariadbclient-dev:i386
+libmariadbclient18
+libmariadbclient18:i386
 libmemcached-dev
 libmemcached-dev:i386
 libmemcached6
@@ -4932,6 +4936,10 @@ manpages
 manpages-dev
 manpages-dev:i386
 manpages:i386
+mariadb-client
+mariadb-client:i386
+mariadb-server
+mariadb-server:i386
 mawk
 mawk:i386
 md5deep


### PR DESCRIPTION
@meatballhat 

The packages come from the external "mariadb-10.0" repository which is already whitelisted: https://github.com/travis-ci/apt-source-whitelist/pull/3

Although the external repository is already whitelisted, each package still has to be whitelisted manually? Without whitelisting Travis fails in my case:

    Installing APT Packages (BETA)
    Disallowing packages: libmariadbclient18, libmariadbclient-dev, mariadb-client, mariadb-server, python-mysqldb

(Output from Travis run: https://travis-ci.org/youtube/vitess/jobs/63267646#L83)