### PR TITLE
White-list lcov package

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -2760,6 +2760,7 @@ language-pack-zu:i386
 latex-xcolor
 latexmk
 latexmk:i386
+lcov
 ldap-utils
 ldnsutils
 ldnsutils:i386


### PR DESCRIPTION
It is required for using coveralls.io with C++ without sudo (and thus using the new container infrastructure).

Closes issue https://github.com/travis-ci/travis-ci/issues/4149 .