### PR TITLE
Add NSIS plugins to the whitelist

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -6197,6 +6197,7 @@ nodejs:i386
 notification-daemon
 notification-daemon:i386
 nsis
+nsis-common
 ntfs-3g
 ntfs-3g:i386
 ntpdate


### PR DESCRIPTION
Nothing fancy. http://packages.ubuntu.com/precise/nsis-common Just required to migrate https://github.com/OpenRA/OpenRA/blob/bleed/.travis.yml. Useful for everybody.