### PR TITLE
Add support for Markdown

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -6036,6 +6036,7 @@ manpages
 manpages-dev
 manpages-dev:i386
 manpages:i386
+markdown
 mawk
 mawk:i386
 mcl


### PR DESCRIPTION
http://packages.ubuntu.com/precise/markdown is the original from http://daringfireball.net/projects/markdown/ written in Perl. Should be safe. Required for migrating https://github.com/OpenRA/OpenRA/blob/bleed/.travis.yml, but useful for other projects.

Closes https://github.com/travis-ci/travis-ci/issues/4328.