### PR TITLE
Whitelist "python-mysqldb" package for Ubuntu Precise

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -6657,6 +6657,8 @@ python-matplotlib-doc:i386
 python-matplotlib:i386
 python-minimal
 python-minimal:i386
+python-mysqldb
+python-mysqldb:i386
 python-nose
 python-nose:i386
 python-numpy


### PR DESCRIPTION
@BanzaiMan 

I'm currently playing around with the Travis CI container. (I worked around the sudo requirement by downloading and extracting the MariaDB 10.0 packages manually.)

Besides the sudo workaround, this package is the only one which isn't approved for the "apt" addon yet. Can you please add it? Thanks!