### PR TITLE
Pull request for libxerces-c-dev

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -5744,6 +5744,7 @@ libxdmcp6
 libxdmcp6:i386
 libxdot4
 libxdot4:i386
+libxerces-c-dev
 libxerces-c28
 libxerces-c28:i386
 libxerces2-java


### PR DESCRIPTION
For travis-ci/travis-ci#4308.

Ran tests and found no setuid bits.

 See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/71937210