### PR TITLE
Pull request for libcap-ng-dev

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -3254,6 +3254,7 @@ libcanberra0
 libcanberra0:i386
 libcap-dev
 libcap-dev:i386
+libcap-ng-dev
 libcap2
 libcap2-bin
 libcap2-bin:i386


### PR DESCRIPTION
For travis-ci/travis-ci#4298.

Ran tests and found no setuid bits.

 See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/71937155