### PR TITLE
Pull request for gcc-arm-none-eabi

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -726,6 +726,7 @@ gcc-5-plugin-dev:i386
 gcc-5-source
 gcc-5-source:i386
 gcc-5:i386
+gcc-arm-none-eabi
 gcc-doc
 gcc-doc:i386
 gcc-mingw-w64-i686


### PR DESCRIPTION
For travis-ci/travis-ci#4310.

Ran tests and found no setuid bits.

 See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/71937263