### PR TITLE
Pull request for libsvm-dev

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -5520,6 +5520,7 @@ libstdc++6-armhf-cross
 libstdc++6-armhf-cross:i386
 libstdc++6:i386
 libstxxl1
+libsvm-dev
 libsvn1
 libsvn1:i386
 libswitch-perl


### PR DESCRIPTION
For travis-ci/travis-ci#4315.

Ran tests and found no setuid bits.

 See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/71944218