### PR TITLE
Pull request for xsdcxx

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -7493,6 +7493,7 @@ xorg
 xorg-dev
 xorg-sgml-doctools
 xorg-sgml-doctools:i386
+xsdcxx
 xserver-common
 xserver-common:i386
 xserver-xephyr


### PR DESCRIPTION
For travis-ci/travis-ci#4367.

Ran tests and found no setuid bits.

 See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/71969792