### PR TITLE
Pull request for libpstreams-dev

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -5137,6 +5137,7 @@ libprotobuf-c0:i386
 libprotobuf-dev
 libprotobuf-dev:i386
 libprotoc-dev
+libpstreams-dev
 libpthread-stubs0
 libpthread-stubs0-dev
 libpthread-stubs0-dev:i386


### PR DESCRIPTION
For travis-ci/travis-ci#4365.

Ran tests and found no setuid bits.

 See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/71969772