### PR TITLE
Pull request for libcoq-ocaml-dev

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -337,6 +337,9 @@ consolekit
 consolekit:i386
 context
 control:
+coq
+coq-theories
+coqide
 coreutils
 coreutils:i386
 couchdb
@@ -3405,6 +3408,8 @@ libconfuse-dev
 libconfuse-dev:i386
 libconfuse0
 libconfuse0:i386
+libcoq-ocaml
+libcoq-ocaml-dev
 libcouchbase-dev
 libcouchbase-dev:i386
 libcouchbase2-libevent


### PR DESCRIPTION
For travis-ci/travis-ci#4441.

Ran tests and found no setuid bits.

 See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/71995942