### PR TITLE
Pull request for python-pexpect

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -6840,6 +6840,8 @@ python-opencv
 python-opencv:i386
 python-paramiko
 python-paramiko:i386
+python-pexpect
+python-pexpect-doc
 python-pip
 python-pip:i386
 python-pkg-resources
@@ -6964,6 +6966,7 @@ python3-ipaddr
 python3-markdown
 python3-minimal
 python3-minimal:i386
+python3-pexpect
 python3-pkg-resources
 python3-pyqt4
 python3-pyqt4-dbg


### PR DESCRIPTION
For travis-ci/travis-ci#4442.

Ran tests and found no setuid bits.

 See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/71996356