### PR TITLE
Pull request for python-numexpr

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -6827,6 +6827,8 @@ python-minimal
 python-minimal:i386
 python-nose
 python-nose:i386
+python-numexpr
+python-numexpr-dbg
 python-numpy
 python-numpy:i386
 python-oauth
@@ -6961,6 +6963,8 @@ python3-ipaddr
 python3-markdown
 python3-minimal
 python3-minimal:i386
+python3-numexpr
+python3-numexpr-dbg
 python3-pexpect
 python3-pkg-resources
 python3-pyqt4


### PR DESCRIPTION
For travis-ci/travis-ci/travis-ci#4314.

Ran tests and found no setuid bits.

 See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/72054253