### PR TITLE
Pull request for snmp-mibs-downloader

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -7127,6 +7127,7 @@ shared-mime-info:i386
 slapd
 sndfile-programs
 sndfile-programs:i386
+snmp-mibs-downloader
 socat
 socklog
 socklog-run


### PR DESCRIPTION
For travis-ci/travis-ci#4345.

Ran tests and found no setuid bits.

 See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/72054264