### PR TITLE
Pull request for libzipios++-dev

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -6028,6 +6028,9 @@ libzeroc-ice34-dbg:i386
 libzeroc-ice34-dev
 libzeroc-ice34-dev:i386
 libzeroc-ice34:i386
+libzipios++-dev
+libzipios++-doc
+libzipios++0c2a
 libzmq-dbg
 libzmq-dbg:i386
 libzmq-dev


### PR DESCRIPTION
For travis-ci/travis-ci/travis-ci#4457.

Ran tests and found no setuid bits.

 See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/72066067