### PR TITLE
Pull request for libspnav-dev

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -5530,6 +5530,8 @@ libsoup2.4-doc
 libsparsehash-dev
 libspatialite3
 libspatialite3:i386
+libspnav-dev
+libspnav0
 libspotify-dev
 libspotify-dev:i386
 libspotify12


### PR DESCRIPTION
For travis-ci/travis-ci#4462.

Ran tests and found no setuid bits.

 See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/72066077