### PR TITLE
Pull request for libnfnetlink-dev

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -4892,7 +4892,9 @@ libnettle4
 libnettle4:i386
 libnewt0.52
 libnewt0.52:i386
+libnfnetlink-dev
 libnfnetlink0
+libnfnetlink0-dbg
 libnfnetlink0:i386
 libnih-dbus1
 libnih-dbus1:i386


### PR DESCRIPTION
For travis-ci/travis-ci#4466.

Ran tests and found no setuid bits.

 See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/72071660