### PR TITLE
Pull request for libprotoc-dev

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -5246,7 +5246,11 @@ libprotobuf-c0-dev:i386
 libprotobuf-c0:i386
 libprotobuf-dev
 libprotobuf-dev:i386
+libprotobuf-java
+libprotobuf-lite9
+libprotobuf9
 libprotoc-dev
+libprotoc9
 libproxychains-dev
 libproxychains3
 libpstreams-dev
@@ -6885,6 +6889,7 @@ python-pip
 python-pip:i386
 python-pkg-resources
 python-pkg-resources:i386
+python-protobuf
 python-pycurl
 python-pycurl:i386
 python-pyfann


### PR DESCRIPTION
For travis-ci/travis-ci#4302.

Ran tests and found no setuid bits.

 See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/72141769