### PR TITLE
Pull request for libsvm-dev

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -5706,6 +5706,10 @@ libstdc++6-armhf-cross:i386
 libstdc++6:i386
 libstxxl1
 libsvm-dev
+libsvm-java
+libsvm-tools
+libsvm3
+libsvm3-java
 libsvn1
 libsvn1:i386
 libswitch-perl
@@ -6850,6 +6854,7 @@ python-lazr.uri
 python-lazr.uri:i386
 python-ldns
 python-ldns:i386
+python-libsvm
 python-libxml2
 python-libxml2-dbg
 python-libxslt1


### PR DESCRIPTION
For travis-ci/travis-ci#4315.

Ran tests and found no setuid bits.

 See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/72172373