### PR TITLE
Pull request for python-markupsafe

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -6859,6 +6859,8 @@ python-lxml:i386
 python-m2crypto
 python-markdown
 python-markdown-doc
+python-markupsafe
+python-markupsafe-dbg
 python-matplotlib
 python-matplotlib-data
 python-matplotlib-data:i386
@@ -7005,6 +7007,8 @@ python3-gi-dbg
 python3-gi:i386
 python3-ipaddr
 python3-markdown
+python3-markupsafe
+python3-markupsafe-dbg
 python3-minimal
 python3-minimal:i386
 python3-pexpect


### PR DESCRIPTION
For travis-ci/travis-ci#4243.

Ran tests and found no setuid bits.

 See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/72206834