### PR TITLE
Pull request for libxerces-c-dev

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -5937,10 +5937,13 @@ libxdmcp6:i386
 libxdot4
 libxdot4:i386
 libxerces-c-dev
+libxerces-c-doc
+libxerces-c-samples
 libxerces-c2-dev
 libxerces-c2-doc
 libxerces-c28
 libxerces-c28:i386
+libxerces-c3.1
 libxerces2-java
 libxerces2-java:i386
 libxext-dev


### PR DESCRIPTION
For travis-ci/travis-ci#4451.

Ran tests and found no setuid bits.

 See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/72206910