### PR TITLE
Pull request for libstdc++-arm-none-eabi-newlib

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -5843,6 +5843,7 @@ libstdc++-5-doc
 libstdc++-5-doc:i386
 libstdc++-5-pic
 libstdc++-5-pic:i386
+libstdc++-arm-none-eabi-newlib
 libstdc++5
 libstdc++5:i386
 libstdc++6


### PR DESCRIPTION
For travis-ci/travis-ci#4540. Ran tests and found no setuid bits. See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/72365280