### PR TITLE
Pull request for libkyotocabinet16

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -1223,6 +1223,8 @@ krb5-multidev
 krb5-multidev:i386
 ksh
 ksh:i386
+kyotocabinet-doc
+kyotocabinet-utils
 lam-mpidoc
 lam-runtime
 lam4-dev
@@ -4499,6 +4501,9 @@ libkrb5-dev
 libkrb5-dev:i386
 libkrb5support0
 libkrb5support0:i386
+libkyotocabinet-dev
+libkyotocabinet16
+libkyotocabinet16-dbg
 liblablgtk2-gl-ocaml
 liblablgtk2-gl-ocaml-dev
 liblablgtk2-gnome-ocaml


### PR DESCRIPTION
Resolves travis-ci/apt-package-whitelist#361.

Add packages: libkyotocabinet16 libkyotocabinet16-dbg kyotocabinet-utils kyotocabinet-doc libkyotocabinet-dev

See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/72545294