### PR TITLE
Pull request for libc++1

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -3336,6 +3336,13 @@ libbz2-1.0
 libbz2-1.0:i386
 libbz2-dev
 libbz2-dev:i386
+libc++-dev
+libc++-helpers
+libc++-test
+libc++1
+libc++abi-dev
+libc++abi-test
+libc++abi1
 libc-ares-dev
 libc-bin
 libc-bin:i386


### PR DESCRIPTION
 Resolves travis-ci/apt-package-whitelist#359.

Add packages: libc++1 libc++-dev libc++-test libc++abi1 libc++abi-dev libc++abi-test libc++-helpers

See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/72545284