### PR TITLE
Pull request for libsdl2-2.0-0

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -5644,6 +5644,9 @@ libsdl1.2-dbg
 libsdl1.2-dev
 libsdl1.2-dev:i386
 libsdl1.2debian
+libsdl2-2.0-0
+libsdl2-dbg
+libsdl2-dev
 libsecret-1-0
 libsecret-1-dev
 libsecret-common


### PR DESCRIPTION
Resolves travis-ci/apt-package-whitelist#366.

Add packages: libsdl2-2.0-0 libsdl2-dev libsdl2-dbg

See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/72545328