### PR TITLE
Pull request for libgstreamer1.0-0

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -947,6 +947,7 @@ gir1.2-glib-2.0:i386
 gir1.2-gnomekeyring-1.0
 gir1.2-gnomekeyring-1.0:i386
 gir1.2-gst-plugins-base-0.10
+gir1.2-gstreamer-1.0
 gir1.2-gtk-2.0
 gir1.2-gtk-2.0:i386
 gir1.2-gtk-3.0
@@ -1061,6 +1062,8 @@ gstreamer0.10-plugins-base-apps
 gstreamer0.10-plugins-base-dbg
 gstreamer0.10-plugins-base-doc
 gstreamer0.10-x
+gstreamer1.0-doc
+gstreamer1.0-tools
 gtk-3-examples
 guile-1.8-libs
 guile-1.8-libs:i386
@@ -4144,6 +4147,9 @@ libgstreamer-plugins-base0.10-0:i386
 libgstreamer-plugins-base0.10-dev
 libgstreamer0.10-0
 libgstreamer0.10-0:i386
+libgstreamer1.0-0
+libgstreamer1.0-0-dbg
+libgstreamer1.0-dev
 libgtest-dev
 libgtk-3-0
 libgtk-3-0-dbg


### PR DESCRIPTION
Resolves travis-ci/apt-package-whitelist#373.

Add packages: libgstreamer1.0-0 libgstreamer1.0-0-dbg libgstreamer1.0-dev gstreamer1.0-doc gstreamer1.0-tools gir1.2-gstreamer-1.0

See https://travis-ci.org/travis-ci/apt-whitelist-checker/builds/72545381