### PR TITLE
Pull request for python-openssl

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -7274,6 +7274,8 @@ python-oauth
 python-oauth:i386
 python-opencv
 python-opencv:i386
+python-openssl
+python-openssl-doc
 python-paramiko
 python-paramiko:i386
 python-pexpect
@@ -7422,6 +7424,7 @@ python3-minimal
 python3-minimal:i386
 python3-numexpr
 python3-numexpr-dbg
+python3-openssl
 python3-pexpect
 python3-pil
 python3-pil-dbg


### PR DESCRIPTION
Resolves travis-ci/apt-package-whitelist#420.
Add packages: python-openssl python-openssl-doc python3-openssl

See http://travis-ci.org/travis-ci/apt-whitelist-checker/builds/72545613.