### PR TITLE
Pull request for libvips38

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -6084,6 +6084,10 @@ libvarnishapi-dev
 libvarnishapi-dev:i386
 libvarnishapi1
 libvarnishapi1:i386
+libvips-dev
+libvips-doc
+libvips-tools
+libvips38
 libvlc-dev
 libvlc-dev:i386
 libvlc5
@@ -7342,6 +7346,7 @@ python-software-properties:i386
 python-sphinx
 python-tables
 python-tables:i386
+python-vipscc
 python-virtualenv
 python-virtualenv:i386
 python-vtk


### PR DESCRIPTION
Resolves travis-ci/apt-package-whitelist#425.
Add packages: libvips38 libvips-dev libvips-tools python-vipscc libvips-doc

See http://travis-ci.org/travis-ci/apt-whitelist-checker/builds/72545621.