### PR TITLE
APT whitelist request for mongodb-org-server PR

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -6755,6 +6755,7 @@ module-init-tools
 module-init-tools:i386
 mongodb-10gen
 mongodb-10gen:i386
+mongodb-org-server
 mono-2.0-gac
 mono-2.0-gac:i386
 mono-2.0-service


### PR DESCRIPTION
request adding mongodb-org-server package, which is officially listed @ http://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/#install-the-latest-stable-version-of-mongodb