### PR TITLE
APT whitelist request for package mongodb-org-shell in ubuntu-precise

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -7456,6 +7456,7 @@ module-init-tools:i386
 mongodb-10gen
 mongodb-10gen:i386
 mongodb-org-server
+mongodb-org-shell
 mono-2.0-gac
 mono-2.0-gac:i386
 mono-2.0-service


### PR DESCRIPTION
When installing mongodb-org-server, you end up with a system without a mongo shell. The MongoDB shell is often used to populate the DB before tests.