### PR TITLE
Adds libopenmpi1.5-dev

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -5876,6 +5876,7 @@ libopenjpeg-dev
 libopenjpeg-java
 libopenjpeg5
 libopenjpeg5-dbg
+libopenmpi1.5-dev
 libopenmpi-dev
 libopenmpi-dev:i386
 libopenscenegraph-dev


### PR DESCRIPTION
The current openmpi implementation is from 2009. 
It would be nice if this could go in soon (I'll review any setuid issues if found).