### PR TITLE
Ubuntu-trusty: APT whitelist requset for libnetfilter-queue-dev,iptables-dev

### DIFF
--- a/ubuntu-trusty
+++ b/ubuntu-trusty
@@ -494,6 +494,7 @@ intltool-debian:i386
 intltool:i386
 iproute
 iptables
+iptables-dev
 iso-codes
 ivy
 java-common
@@ -2995,6 +2996,9 @@ libneon27-gnutls
 libnet-daemon-perl
 libnet-daemon-perl:i386
 libnetcdf6
+libnetfilter-queue-dev
+libnetfilter-queue1
+libnetfilter-queue1-dbg
 libnetpbm10
 libnettle4
 libnfnetlink0


### PR DESCRIPTION
Resolves: travis-ci/apt-package-whitelist/issues/4039
Add packages: libnetfilter-queue-dev, libnetfilter-queue1, libnetfilter-queue1-dbg, iptables-dev